### PR TITLE
unify space related functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,11 +127,6 @@ pub struct FsStats {
 }
 
 impl FsStats {
-    /// Get the stats of the file system containing the provided path.
-    pub fn statvfs<P>(path: P) -> Result<FsStats> where P: AsRef<Path> {
-        sys::statvfs(path)
-    }
-
     /// Returns the number of free bytes in the file system containing the provided
     /// path.
     pub fn free_space(&self) -> u64 {
@@ -160,22 +155,27 @@ impl FsStats {
     }
 }
 
+/// Get the stats of the file system containing the provided path.
+pub fn statvfs<P>(path: P) -> Result<FsStats> where P: AsRef<Path> {
+    sys::statvfs(path.as_ref())
+}
+
 /// Returns the number of free bytes in the file system containing the provided
 /// path.
 pub fn free_space<P>(path: P) -> Result<u64> where P: AsRef<Path> {
-    FsStats::statvfs(path).map(|stat| stat.free_space)
+    statvfs(path).map(|stat| stat.free_space)
 }
 
 /// Returns the available space in bytes to non-priveleged users in the file
 /// system containing the provided path.
 pub fn available_space<P>(path: P) -> Result<u64> where P: AsRef<Path> {
-    FsStats::statvfs(path).map(|stat| stat.available_space)
+    statvfs(path).map(|stat| stat.available_space)
 }
 
 /// Returns the total space in bytes in the file system containing the provided
 /// path.
 pub fn total_space<P>(path: P) -> Result<u64> where P: AsRef<Path> {
-    FsStats::statvfs(path).map(|stat| stat.total_space)
+    statvfs(path).map(|stat| stat.total_space)
 }
 
 /// Returns the filesystem's disk space allocation granularity in bytes.
@@ -184,7 +184,7 @@ pub fn total_space<P>(path: P) -> Result<u64> where P: AsRef<Path> {
 /// On Posix, this is equivalent to the filesystem's block size.
 /// On Windows, this is equivalent to the filesystem's cluster size.
 pub fn allocation_granularity<P>(path: P) -> Result<u64> where P: AsRef<Path> {
-    FsStats::statvfs(path).map(|stat| stat.allocation_granularity)
+    statvfs(path).map(|stat| stat.allocation_granularity)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ pub fn lock_contended_error() -> Error {
 }
 
 /// FsStats contains some common stats about a file system.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FsStats {
     free_space: u64,
     available_space: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,22 +118,64 @@ pub fn lock_contended_error() -> Error {
     sys::lock_error()
 }
 
+/// FsStats contains some common stats about a file system.
+pub struct FsStats {
+    free_space: u64,
+	available_space: u64,
+	total_space: u64,
+	allocation_granularity: u64,
+}
+
+impl FsStats {
+    /// Get the stats of the file system containing the provided path.
+    pub fn statvfs<P>(path: P) -> Result<FsStats> where P: AsRef<Path> {
+	    sys::statvfs(path)
+    }
+	
+    /// Returns the number of free bytes in the file system containing the provided
+    /// path.
+    pub fn free_space(&self) -> u64 {
+	    self.free_space
+    }
+
+    /// Returns the available space in bytes to non-priveleged users in the file
+    /// system containing the provided path.
+    pub fn available_space(&self) -> u64 {
+        self.available_space
+    }
+
+    /// Returns the total space in bytes in the file system containing the provided
+    /// path.
+    pub fn total_space(&self) -> u64 {
+        self.total_space
+    }
+
+    /// Returns the filesystem's disk space allocation granularity in bytes.
+    /// The provided path may be for any file in the filesystem.
+    ///
+    /// On Posix, this is equivalent to the filesystem's block size.
+    /// On Windows, this is equivalent to the filesystem's cluster size.
+    pub fn allocation_granularity(&self) -> u64 {
+        self.allocation_granularity
+    }
+}
+
 /// Returns the number of free bytes in the file system containing the provided
 /// path.
 pub fn free_space<P>(path: P) -> Result<u64> where P: AsRef<Path> {
-    sys::free_space(path)
+    FsStats::statvfs(path).map(|stat| stat.free_space)
 }
 
 /// Returns the available space in bytes to non-priveleged users in the file
 /// system containing the provided path.
 pub fn available_space<P>(path: P) -> Result<u64> where P: AsRef<Path> {
-    sys::available_space(path)
+    FsStats::statvfs(path).map(|stat| stat.available_space)
 }
 
 /// Returns the total space in bytes in the file system containing the provided
 /// path.
 pub fn total_space<P>(path: P) -> Result<u64> where P: AsRef<Path> {
-    sys::total_space(path)
+    FsStats::statvfs(path).map(|stat| stat.total_space)
 }
 
 /// Returns the filesystem's disk space allocation granularity in bytes.
@@ -142,7 +184,7 @@ pub fn total_space<P>(path: P) -> Result<u64> where P: AsRef<Path> {
 /// On Posix, this is equivalent to the filesystem's block size.
 /// On Windows, this is equivalent to the filesystem's cluster size.
 pub fn allocation_granularity<P>(path: P) -> Result<u64> where P: AsRef<Path> {
-    sys::allocation_granularity(path)
+    FsStats::statvfs(path).map(|stat| stat.allocation_granularity)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,21 +121,21 @@ pub fn lock_contended_error() -> Error {
 /// FsStats contains some common stats about a file system.
 pub struct FsStats {
     free_space: u64,
-	available_space: u64,
-	total_space: u64,
-	allocation_granularity: u64,
+    available_space: u64,
+    total_space: u64,
+    allocation_granularity: u64,
 }
 
 impl FsStats {
     /// Get the stats of the file system containing the provided path.
     pub fn statvfs<P>(path: P) -> Result<FsStats> where P: AsRef<Path> {
-	    sys::statvfs(path)
+        sys::statvfs(path)
     }
-	
+
     /// Returns the number of free bytes in the file system containing the provided
     /// path.
     pub fn free_space(&self) -> u64 {
-	    self.free_space
+        self.free_space
     }
 
     /// Returns the available space in bytes to non-priveleged users in the file

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -109,8 +109,8 @@ pub fn allocate(file: &File, len: u64) -> Result<()> {
     }
 }
 
-pub fn statvfs<P>(path: P) -> Result<FsStats> where P: AsRef<Path> {
-    let cstr = match CString::new(path.as_ref().as_os_str().as_bytes()) {
+pub fn statvfs(path: &Path) -> Result<FsStats> {
+    let cstr = match CString::new(path.as_os_str().as_bytes()) {
         Ok(cstr) => cstr,
         Err(..) => return Err(Error::new(ErrorKind::InvalidInput, "path contained a null")),
     };

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -105,8 +105,8 @@ fn lock_file(file: &File, flags: winapi::DWORD) -> Result<()> {
     }
 }
 
-fn volume_path<P>(path: P, volume_path: &mut [u16]) -> Result<()> where P: AsRef<Path> {
-    let path_utf8: Vec<u16> = path.as_ref().as_os_str().encode_wide().chain(Some(0)).collect();
+fn volume_path(path: &Path, volume_path: &mut [u16]) -> Result<()> {
+    let path_utf8: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
     unsafe {
         let ret = kernel32::GetVolumePathNameW(path_utf8.as_ptr(),
                                                volume_path.as_mut_ptr(),
@@ -116,7 +116,7 @@ fn volume_path<P>(path: P, volume_path: &mut [u16]) -> Result<()> where P: AsRef
     }
 }
 
-pub fn statvfs<P>(path: P) -> Result<FsStats> where P: AsRef<Path> {
+pub fn statvfs(path: &Path) -> Result<FsStats> {
     let root_path: &mut [u16] = &mut [0; 261];
     try!(volume_path(path, root_path));
     unsafe {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -9,6 +9,8 @@ use std::os::windows::io::{AsRawHandle, FromRawHandle};
 use std::path::Path;
 use std::ptr;
 
+use FsStats;
+
 pub fn duplicate(file: &File) -> Result<File> {
     unsafe {
         let mut handle = ptr::null_mut();
@@ -114,7 +116,7 @@ fn volume_path<P>(path: P, volume_path: &mut [u16]) -> Result<()> where P: AsRef
     }
 }
 
-fn get_disk_free_space<P>(path: P) -> Result<(u64, u64, u64, u64)> where P: AsRef<Path> {
+pub fn statvfs<P>(path: P) -> Result<FsStats> where P: AsRef<Path> {
     let root_path: &mut [u16] = &mut [0; 261];
     try!(volume_path(path, root_path));
     unsafe {
@@ -131,40 +133,17 @@ fn get_disk_free_space<P>(path: P) -> Result<(u64, u64, u64, u64)> where P: AsRe
         if ret == 0 {
             Err(Error::last_os_error())
         } else {
-            Ok((sectors_per_cluster as u64,
-                bytes_per_sector as u64,
-                number_of_free_clusters as u64,
-                total_number_of_clusters as u64))
+            let bytes_per_cluster = sectors_per_cluster as u64 * bytes_per_sector as u64;
+            let free_space = bytes_per_cluster * number_of_free_clusters as u64;
+            let total_space = bytes_per_cluster * total_number_of_clusters as u64;
+            Ok(FsStats {
+                free_space: free_space,
+                available_space: free_space,
+                total_space: total_space,
+                allocation_granularity: bytes_per_cluster,
+            })
         }
     }
-}
-
-pub fn free_space<P>(path: P) -> Result<u64> where P: AsRef<Path> {
-    available_space(path)
-}
-
-pub fn available_space<P>(path: P) -> Result<u64> where P: AsRef<Path> {
-    get_disk_free_space(path).map(|(sectors_per_cluster,
-                                    bytes_per_sector,
-                                    number_of_free_clusters,
-                                    _)| {
-        number_of_free_clusters * sectors_per_cluster * bytes_per_sector
-    })
-}
-
-pub fn total_space<P>(path: P) -> Result<u64> where P: AsRef<Path> {
-    get_disk_free_space(path).map(|(sectors_per_cluster,
-                                    bytes_per_sector,
-                                    _,
-                                    total_number_of_clusters)| {
-        total_number_of_clusters * sectors_per_cluster * bytes_per_sector
-    })
-}
-
-pub fn allocation_granularity<P>(path: P) -> Result<u64> where P: AsRef<Path> {
-    get_disk_free_space(path).map(|(sectors_per_cluster, bytes_per_sector, _, _)| {
-        sectors_per_cluster * bytes_per_sector
-    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
If caller wants to get both available space and total space, he has to call `statvfs` or `get_disk_free_space` twice, which is unnecessary. This pr unify all the space related functions so caller can get all these stats at once.