### PR TITLE
Use weak symbols to use flock() if found, or fcntl() otherwise

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,10 @@
 #![deny(warnings)]
 
 #[cfg(unix)]
+#[macro_use]
+mod weak;
+
+#[cfg(unix)]
 mod unix;
 #[cfg(unix)]
 use unix as sys;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -86,7 +86,7 @@ fn fcntl_flock(file: &File, flag: libc::c_int) -> Result<()> {
 }
 
 #[cfg(not(target_os = "solaris"))]
-fn fcntl_flock(file: &File, flag: libc::c_int) -> Result<()> {
+fn fcntl_flock(_: &File, _: libc::c_int) -> Result<()> {
     panic!("Only Solaris should need fcntl-based flock emulation!")
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -47,9 +47,53 @@ pub fn lock_error() -> Error {
     Error::from_raw_os_error(libc::EWOULDBLOCK)
 }
 
+// Simulate flock() using fcntl(); primarily for Oracle Solaris.
+fn solaris_flock(file: &File, flag: libc::c_int) -> Result<()> {
+    let mut fl = libc::flock {
+        l_whence: 0,
+        l_start: 0,
+        l_len: 0,
+        l_type: 0,
+        l_pad: [0; 4],
+        l_pid: 0,
+        l_sysid: 0,
+    };
+
+    // In non-blocking mode, use F_SETLK for cmd, F_SETLKW otherwise, and don't forget to clear
+    // LOCK_NB.
+    let (cmd, operation) = match flag & libc::LOCK_NB {
+        0 => (libc::F_SETLKW, flag),
+        _ => (libc::F_SETLK, flag & !libc::LOCK_NB),
+    };
+
+    match operation {
+        libc::LOCK_SH => fl.l_type |= libc::F_RDLCK,
+        libc::LOCK_EX => fl.l_type |= libc::F_WRLCK,
+        libc::LOCK_UN => fl.l_type |= libc::F_UNLCK,
+        _ => return Err(Error::from_raw_os_error(libc::EINVAL)),
+    }
+
+    let ret = unsafe { libc::fcntl(file.as_raw_fd(), cmd, &fl) };
+    match ret {
+        // Translate EACCES to EWOULDBLOCK
+        -1 => match Error::last_os_error().raw_os_error() {
+            Some(libc::EACCES) => return Err(lock_error()),
+            _ => return Err(Error::last_os_error())
+        },
+        _ => Ok(())
+    }
+}
+
 fn flock(file: &File, flag: libc::c_int) -> Result<()> {
-    let ret = unsafe { libc::flock(file.as_raw_fd(), flag) };
-    if ret < 0 { Err(Error::last_os_error()) } else { Ok(()) }
+    weak!(fn flock(libc::c_int, libc::c_int) -> libc::c_int);
+
+    match flock.get() {
+        Some(f) => {
+            let ret = unsafe { f(file.as_raw_fd(), flag) };
+            if ret < 0 { Err(Error::last_os_error()) } else { Ok(()) }
+        },
+        None => solaris_flock(file, flag),
+    }
 }
 
 pub fn allocated_size(file: &File) -> Result<u64> {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -85,7 +85,7 @@ fn solaris_flock(file: &File, flag: libc::c_int) -> Result<()> {
 }
 
 fn flock(file: &File, flag: libc::c_int) -> Result<()> {
-    weak!(fn flock(libc::c_int, libc::c_int) -> libc::c_int);
+    let flock = ::weak::WeakFlock::new();
 
     match flock.get() {
         Some(f) => {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -48,6 +48,7 @@ pub fn lock_error() -> Error {
 }
 
 // Simulate flock() using fcntl(); primarily for Oracle Solaris.
+#[cfg(target_os = "solaris")]
 fn solaris_flock(file: &File, flag: libc::c_int) -> Result<()> {
     let mut fl = libc::flock {
         l_whence: 0,

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -8,23 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Support for "weak linkage" to symbols on Unix
+//! Provide a "WeakFlock" struct that wraps a possibly nonexistent flock() libc function.
 //!
-//! Some I/O operations we do in libstd require newer versions of OSes but we
-//! need to maintain binary compatibility with older releases for now. In order
-//! to use the new functionality when available we use this module for
-//! detection.
-//!
-//! One option to use here is weak linkage, but that is unfortunately only
-//! really workable on Linux. Hence, use dlsym to get the symbol value at
-//! runtime. This is also done for compatibility with older versions of glibc,
-//! and to avoid creating dependencies on GLIBC_PRIVATE symbols. It assumes that
-//! we've been dynamically linked to the library the symbol comes from, but that
-//! is currently always the case for things like libpthread/libc.
-//!
-//! A long time ago this used weak linkage for the __pthread_get_minstack
-//! symbol, but that caused Debian to detect an unnecessarily strict versioned
-//! dependency on libc6 (#23628).
+//! This borrows from libstd/sys/unix/weak.rs, removing the generic aspects that are available only
+//! in a nightly build.
 
 extern crate libc;
 
@@ -33,34 +20,25 @@ use std::marker;
 use std::mem;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-#[macro_export]
-macro_rules! weak {
-    (fn $name:ident($($t:ty),*) -> $ret:ty) => (
-        /* static */ $name: ::weak::Weak<unsafe extern fn($($t),*) -> $ret> =
-            ::weak::Weak::new(stringify!($name));
-    )
-}
+type FlockFunc = unsafe extern fn(libc::c_int, libc::c_int) -> libc::c_int;
 
-pub struct Weak<F> {
+pub struct WeakFlock {
     name: &'static str,
     addr: AtomicUsize,
-    _marker: marker::PhantomData<F>,
+    _marker: marker::PhantomData<FlockFunc>,
 }
 
-// Remove the const here and the static in the macro because "const fn" isn't available outside of
-// nightly yet (see RFC 911 and issue 24111).  But then we run into type ascription not being
-// implemented.
-impl<F> Weak<F> {
-    pub /* const */ fn new(name: &'static str) -> Weak<F> {
-        Weak {
-            name: name,
+impl WeakFlock {
+    pub fn new() -> WeakFlock {
+        WeakFlock {
+            name: &"flock",
             addr: AtomicUsize::new(1),
             _marker: marker::PhantomData,
         }
     }
 
-    pub fn get(&self) -> Option<&F> {
-        assert_eq!(mem::size_of::<F>(), mem::size_of::<usize>());
+    pub fn get(&self) -> Option<&FlockFunc> {
+        assert_eq!(mem::size_of::<FlockFunc>(), mem::size_of::<usize>());
         unsafe {
             if self.addr.load(Ordering::SeqCst) == 1 {
                 self.addr.store(fetch(self.name), Ordering::SeqCst);
@@ -68,7 +46,7 @@ impl<F> Weak<F> {
             if self.addr.load(Ordering::SeqCst) == 0 {
                 None
             } else {
-                mem::transmute::<&AtomicUsize, Option<&F>>(&self.addr)
+                mem::transmute::<&AtomicUsize, Option<&FlockFunc>>(&self.addr)
             }
         }
     }

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -20,7 +20,7 @@ use std::marker;
 use std::mem;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-type FlockFunc = unsafe extern fn(libc::c_int, libc::c_int) -> libc::c_int;
+pub type FlockFunc = unsafe extern fn(libc::c_int, libc::c_int) -> libc::c_int;
 
 pub struct WeakFlock {
     name: &'static str,

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -1,0 +1,83 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Support for "weak linkage" to symbols on Unix
+//!
+//! Some I/O operations we do in libstd require newer versions of OSes but we
+//! need to maintain binary compatibility with older releases for now. In order
+//! to use the new functionality when available we use this module for
+//! detection.
+//!
+//! One option to use here is weak linkage, but that is unfortunately only
+//! really workable on Linux. Hence, use dlsym to get the symbol value at
+//! runtime. This is also done for compatibility with older versions of glibc,
+//! and to avoid creating dependencies on GLIBC_PRIVATE symbols. It assumes that
+//! we've been dynamically linked to the library the symbol comes from, but that
+//! is currently always the case for things like libpthread/libc.
+//!
+//! A long time ago this used weak linkage for the __pthread_get_minstack
+//! symbol, but that caused Debian to detect an unnecessarily strict versioned
+//! dependency on libc6 (#23628).
+
+extern crate libc;
+
+use std::ffi::CString;
+use std::marker;
+use std::mem;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[macro_export]
+macro_rules! weak {
+    (fn $name:ident($($t:ty),*) -> $ret:ty) => (
+        /* static */ $name: ::weak::Weak<unsafe extern fn($($t),*) -> $ret> =
+            ::weak::Weak::new(stringify!($name));
+    )
+}
+
+pub struct Weak<F> {
+    name: &'static str,
+    addr: AtomicUsize,
+    _marker: marker::PhantomData<F>,
+}
+
+// Remove the const here and the static in the macro because "const fn" isn't available outside of
+// nightly yet (see RFC 911 and issue 24111).  But then we run into type ascription not being
+// implemented.
+impl<F> Weak<F> {
+    pub /* const */ fn new(name: &'static str) -> Weak<F> {
+        Weak {
+            name: name,
+            addr: AtomicUsize::new(1),
+            _marker: marker::PhantomData,
+        }
+    }
+
+    pub fn get(&self) -> Option<&F> {
+        assert_eq!(mem::size_of::<F>(), mem::size_of::<usize>());
+        unsafe {
+            if self.addr.load(Ordering::SeqCst) == 1 {
+                self.addr.store(fetch(self.name), Ordering::SeqCst);
+            }
+            if self.addr.load(Ordering::SeqCst) == 0 {
+                None
+            } else {
+                mem::transmute::<&AtomicUsize, Option<&F>>(&self.addr)
+            }
+        }
+    }
+}
+
+unsafe fn fetch(name: &str) -> usize {
+    let name = match CString::new(name) {
+        Ok(cstr) => cstr,
+        Err(..) => return 0,
+    };
+    libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr()) as usize
+}


### PR DESCRIPTION
Solaris does not yet implement `flock()`, but since cargo uses `flock()` from fs2, some form of implementation is necessary.  The `fcntl()`-based implementation has serious issues, but is enough for cargo to build and operate properly.

I'm using weak symbols to find `flock()`, which means that as soon as Solaris implements it natively, it will immediately start using it, rather than having to wait for a patch to fs2 to remove this implementation. This is particularly helpful since it will work across all versions of Solaris, where older ones might not have a native `flock()` implementation, but newer ones do.

The only other alternative (as seen in my `solaris-flock` branch) is to use a build script to do an autoconf-style test, but that has the usual downsides of build scripts.