### PR TITLE
Fix large file allocation for 32 bit unix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,6 +318,23 @@ mod test {
         assert_eq!(blksize + 1, file.metadata().unwrap().len());
     }
 
+    /// Tests large file allocation
+    #[test]
+    fn large_file_allocation() {
+        let tempdir = tempdir::TempDir::new("fs2").unwrap();
+        let path = tempdir.path().join("fs2");
+        let file = fs::OpenOptions::new().write(true).create(true).open(&path).unwrap();
+
+        // New files are created with no allocated size.
+        assert_eq!(0, file.metadata().unwrap().len());
+
+        // Allocate space for a 2Gb file to check for 64 bit size support.
+
+        file.allocate(0x80000000).unwrap();
+
+        assert_eq!(0x80000000, file.metadata().unwrap().len());
+    }
+
     /// Checks filesystem space methods.
     #[test]
     fn filesystem_space() {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -101,7 +101,7 @@ pub fn allocated_size(file: &File) -> Result<u64> {
           target_os = "emscripten",
           target_os = "nacl"))]
 pub fn allocate(file: &File, len: u64) -> Result<()> {
-    let ret = unsafe { libc::posix_fallocate(file.as_raw_fd(), 0, len as libc::off_t) };
+    let ret = unsafe { libc::posix_fallocate64(file.as_raw_fd(), 0, len as libc::off64_t) };
     if ret == 0 { Ok(()) } else { Err(Error::last_os_error()) }
 }
 


### PR DESCRIPTION
File allocations over 2Gb that use the `allocate` method currently fail on 32 bit unix as `libc::off_t` is defined as 32 bit. Using `posix_fallocate64` with a `libc::off64_t` fixes it.

The test requires that your tempdir has at least 2Gb free and can support files that are 2Gb in size. Not sure this is a great requirement, but not sure how else to test it.