### PR TITLE
Add support for illumos target

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -140,6 +140,7 @@ pub fn allocate(file: &File, len: u64) -> Result<()> {
           target_os = "netbsd",
           target_os = "dragonfly",
           target_os = "solaris",
+          target_os = "illumos",
           target_os = "haiku"))]
 pub fn allocate(file: &File, len: u64) -> Result<()> {
     // No file allocation API available, just set the length if necessary.


### PR DESCRIPTION
As part of the preparation for rust-lang/rust#55553, add support for the Solaris-like illumos target.