### PR TITLE
fix the error handling of `allocate`

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -101,7 +101,7 @@ pub fn allocated_size(file: &File) -> Result<u64> {
           target_os = "emscripten",
           target_os = "nacl"))]
 pub fn allocate(file: &File, len: u64) -> Result<()> {
-    let ret = unsafe { libc::posix_fallocate(file.as_raw_fd(), 0, len as libc::off_t) };
+    let ret = unsafe { libc::fallocate(file.as_raw_fd(), 0 /*mode*/, 0 /*offset*/, len as libc::off_t) };
     if ret == 0 { Ok(()) } else { Err(Error::last_os_error()) }
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -101,8 +101,8 @@ pub fn allocated_size(file: &File) -> Result<u64> {
           target_os = "emscripten",
           target_os = "nacl"))]
 pub fn allocate(file: &File, len: u64) -> Result<()> {
-    let ret = unsafe { libc::fallocate(file.as_raw_fd(), 0 /*mode*/, 0 /*offset*/, len as libc::off_t) };
-    if ret == 0 { Ok(()) } else { Err(Error::last_os_error()) }
+    let ret = unsafe { libc::posix_fallocate(file.as_raw_fd(), 0 /*offset*/, len as libc::off_t) };
+    if ret == 0 { Ok(()) } else { Err(Error::from_raw_os_error(ret)) }
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]


### PR DESCRIPTION
[Man page](https://man7.org/linux/man-pages/man3/posix_fallocate.3.html) states that `posix_fallocate` does not set errno on failure, which means the current handling of allocation is incorrect.

We encounter this issue in https://github.com/tikv/tikv/issues/10688, in which unrelated error message is emitted after disk is full.

~Replacing `posix_fallocate` with `fallocate` might also improve performance on Linux.~