### PR TITLE
Added tvOS target to allocate

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -105,7 +105,7 @@ pub fn allocate(file: &File, len: u64) -> Result<()> {
     if ret == 0 { Ok(()) } else { Err(Error::last_os_error()) }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
 pub fn allocate(file: &File, len: u64) -> Result<()> {
     let stat = try!(file.metadata());
 


### PR DESCRIPTION
This change adds allocate to tvOS target as well as iOS and macOS. 

How was this tested:

- `cargo +nightly build -Z build-std --lib --target aarch64-apple-tvos-sim -v` passed
- `cargo +nightly build -Z build-std --lib --target aarch64-apple-tvos -v` passed

- `cargo +nightly build -Z build-std --lib --target aarch64-apple-ios-sim -v` passed
- `cargo +nightly build -Z build-std --lib --target aarch64-apple-ios -v` passed

- cargo test -v